### PR TITLE
Add the keyPrefix to food items in the setup screen

### DIFF
--- a/src/setup/SetupScreen.js
+++ b/src/setup/SetupScreen.js
@@ -84,6 +84,7 @@ class SetupScreen extends React.Component {
 		}, foods).map(food => {
 			return FoodList.createItem(
 				food.id,
+				"Group food",
 				I18n.t(food.nameTranslationKey),
 				food.thumbnail
 			);


### PR DESCRIPTION
ommiting them was causing food items to display with no picture and their names being a number

Fixes #19 